### PR TITLE
minihack: Add seeds argument and functionality

### DIFF
--- a/nle/minihack/base.py
+++ b/nle/minihack/base.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+import random
 
 import gym
 import numpy as np
@@ -95,6 +96,7 @@ class MiniHack(NetHackStaircase):
         obs_crop_pad=0,
         reward_manager=None,
         use_wiki=False,
+        seeds=None,
         **kwargs,
     ):
         # No pet
@@ -127,6 +129,8 @@ class MiniHack(NetHackStaircase):
         self.reward_manager = reward_manager
         if self.reward_manager is not None:
             self.reward_manager.reset()
+
+        self._level_seeds = seeds
 
         super().__init__(*args, **kwargs)
 
@@ -176,6 +180,9 @@ class MiniHack(NetHackStaircase):
     def reset(self, *args, **kwargs):
         if self.reward_manager is not None:
             self.reward_manager.reset()
+        if self._level_seeds is not None:
+            seed = random.choice(self._level_seeds)
+            self.seed(seed, seed, reseed=False)
         return super().reset(*args, **kwargs)
 
     def _reward_fn(self, last_observation, observation, end_status):


### PR DESCRIPTION
Add the ability for users to specfifying the seeds used to generate the
levels. This allows tighter control over the generation process, and the
ability to test generalisation to levels that are guaranteed to be
unseen.

The `env.seed` method could be use already if desired, but it would
require a more manual approach which wraps the environments and handles
the seeding. This method will allow users to easily specify the seeds to
be used, giving a clean train/test split.